### PR TITLE
Please remove "remaining". eat all the space in top bar

### DIFF
--- a/batterypercentageandtime@copong.gmail.com/power.js
+++ b/batterypercentageandtime@copong.gmail.com/power.js
@@ -34,7 +34,7 @@ var Indicator = class extends BaseIndicator {
       let hours = Math.floor(time / 60);
 
       // Translators: this is <hours>:<minutes>
-      return _("%s - %d\u2236%02d remaining").format(percentage, hours, minutes);
+      return _("%s - %d\u2236%02d").format(percentage, hours, minutes);
    }
 
    _sync() {


### PR DESCRIPTION
Please remove "remaining". eat all the space in top bar. I am using your plugin in ubuntu 18.04