### PR TITLE
added init() to extension.js

### DIFF
--- a/batterypercentageandtime@copong.gmail.com/extension.js
+++ b/batterypercentageandtime@copong.gmail.com/extension.js
@@ -30,3 +30,7 @@ function disable() {
    baTime.destroy();
    baTime = null;
 }
+
+function init() {
+   return new BaTimeExtension();
+}


### PR DESCRIPTION
According to
https://gjs.guide/extensions/overview/anatomy.html#extension-js-required,
the extension.js should contain an init() function. Adding this function
allows the extension to be properly initialized on login/returning
from suspend.